### PR TITLE
[류제영] 제품 리뷰 목록 조회 기능 및 좋아요 기능 구현

### DIFF
--- a/db/migrations/20230925103101_modify_reviews_table.sql
+++ b/db/migrations/20230925103101_modify_reviews_table.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+ALTER TABLE reviews MODIFY image_url VARCHAR(700) NULL UNIQUE;
+ALTER TABLE reviews MODIFY grade TINYINT NOT NULL,
+
+
+-- migrate:down
+ALTER TABLE reviews MODIFY image_url VARCHAR(1000) NOT NULL UNIQUE;
+ALTER TABLE reviews MODIFY grade DECIMAL(2,1) NOT NULL,
+

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,5 +1,7 @@
 const productController = require("./productController");
+const reviewController = require("./reviewController");
 
 module.exports = {
   productController,
+  reviewController,
 };

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,7 +1,9 @@
 const productController = require("./productController");
 const reviewController = require("./reviewController");
+const likeController = require("./likeController");
 
 module.exports = {
   productController,
   reviewController,
+  likeController,
 };

--- a/src/controllers/likeController.js
+++ b/src/controllers/likeController.js
@@ -1,0 +1,15 @@
+const { likeService } = require("../services");
+
+const pushLike = async (req, res) => {
+  const foundUser = req.foundUser;
+  const userId = foundUser ? foundUser.id : undefined;
+  const productId = req.body.productId;
+
+  await likeService.pushLike(userId, productId);
+
+  res.status(200).json({ message: "LIKE_PUSHED" });
+};
+
+module.exports = {
+  pushLike,
+};

--- a/src/controllers/reviewController.js
+++ b/src/controllers/reviewController.js
@@ -1,0 +1,19 @@
+const { reviewService } = require("../services");
+
+const findReviewByProductId = async (req, res) => {
+  const foundUser = req.foundUser;
+  const userId = foundUser ? foundUser.id : undefined;
+  const productId = req.params.id;
+  const { page = 1, image = 0 } = req.query;
+
+  const reviews = await reviewService.findReviewByProductId(userId, productId, image, page);
+
+  res.status(200).json({
+    message: "READ_REVIEW_SUCCESS",
+    data: reviews,
+  });
+};
+
+module.exports = {
+  findReviewByProductId,
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,6 +1,7 @@
 const userDao = require("./userDao");
 const productDao = require("./productDao");
 const reviewDao = require("./reviewDao");
+const likeDao = require("./likeDao");
 const productQueryBuilder = require("./productQueryBuilder");
 const reviewQueryBuilder = require("./reviewQueryBuilder");
 
@@ -8,6 +9,7 @@ module.exports = {
   userDao,
   productDao,
   reviewDao,
+  likeDao,
   productQueryBuilder,
   reviewQueryBuilder,
 };

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,9 +1,13 @@
 const userDao = require("./userDao");
 const productDao = require("./productDao");
+const reviewDao = require("./reviewDao");
 const productQueryBuilder = require("./productQueryBuilder");
+const reviewQueryBuilder = require("./reviewQueryBuilder");
 
 module.exports = {
   userDao,
   productDao,
+  reviewDao,
   productQueryBuilder,
+  reviewQueryBuilder,
 };

--- a/src/models/likeDao.js
+++ b/src/models/likeDao.js
@@ -1,0 +1,64 @@
+const { myDataSource } = require("./dataSource");
+
+const save = async (userId, productId) => {
+  await myDataSource.query(
+    `
+    INSERT INTO likes (
+      user_id,
+      product_id
+    )
+    VALUES (?, ?)
+    `,
+    [userId, productId],
+  );
+};
+
+const findByIds = async (userId, productId) => {
+  const [likes] = await myDataSource.query(
+    `
+    SELECT 
+      user_id
+    FROM 
+      likes
+    WHERE 
+      user_id = ?
+    AND
+      product_id = ?
+    LIMIT 1
+    `,
+    [userId, productId],
+  );
+
+  return likes;
+};
+
+const deleteByIds = async (userId, productId) => {
+  await myDataSource.query(
+    `
+    DELETE FROM likes 
+    WHERE 
+      user_id = ?
+    AND
+      product_id = ?
+    `,
+    [userId, productId],
+  );
+};
+
+const count = async (productId) => {
+  const [result] = await myDataSource.query(
+    `
+    SELECT 
+      COUNT(*) 
+    FROM 
+      likes
+    WHERE
+      product_id = ?
+    `,
+    [productId],
+  );
+
+  return result["COUNT(*)"];
+};
+
+module.exports = { save, findByIds, deleteByIds, count };

--- a/src/models/reviewDao.js
+++ b/src/models/reviewDao.js
@@ -1,0 +1,43 @@
+const { myDataSource } = require("./dataSource");
+
+const findReviewByProductId = async (userId, productId, whereQuery, page) => {
+  return await myDataSource.query(
+    `
+    SELECT
+      u.login_id AS loginId,
+      r.content,
+      r.grade,
+      DATE_FORMAT(r.created_at, '%Y.%m.%d') AS createdAt,
+      r.image_url AS imageUrl,
+      EXISTS (SELECT id FROM reviews WHERE user_id = ? AND id = r.id) AS isMyReview
+    FROM
+      reviews r
+    LEFT JOIN
+      users u ON u.id = r.user_id
+    WHERE
+      r.product_id = ?
+    ${whereQuery}
+    LIMIT 10 OFFSET ?
+    `,
+    [userId, productId, (page - 1) * 10],
+  );
+};
+
+const countReviews = async (whereQuery) => {
+  const [result] = await myDataSource.query(
+    `
+    SELECT 
+      COUNT(*)
+    FROM
+      reviews r
+    ${whereQuery}
+    `,
+  );
+
+  return result["COUNT(*)"];
+};
+
+module.exports = {
+  findReviewByProductId,
+  countReviews,
+};

--- a/src/models/reviewQueryBuilder.js
+++ b/src/models/reviewQueryBuilder.js
@@ -1,0 +1,9 @@
+const whereQuery = (image, isCount) => {
+  if (isCount) return image != 0 && image ? "WHERE r.image_url IS NOT NULL" : "";
+
+  return image != 0 && image ? "AND r.image_url IS NOT NULL" : "";
+};
+
+module.exports = {
+  whereQuery,
+};

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -1,7 +1,9 @@
 const express = require("express");
 const { productRouter } = require("./productRouter");
+const { likeRouter } = require("./likeRouter");
 const router = express.Router();
 
 router.use("/products", productRouter);
+router.use("/likes", likeRouter);
 
 module.exports = router;

--- a/src/routers/likeRouter.js
+++ b/src/routers/likeRouter.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const { likeController } = require("../controllers");
+const { asyncWrap } = require("../utils/errorHandler");
+const { validateToken } = require("../utils/validateToken");
+const likeRouter = express.Router();
+
+likeRouter.post("/", validateToken, asyncWrap(likeController.pushLike));
+
+module.exports = { likeRouter };

--- a/src/routers/productRouter.js
+++ b/src/routers/productRouter.js
@@ -1,10 +1,12 @@
 const express = require("express");
-const { productController } = require("../controllers");
+const { productController, reviewController } = require("../controllers");
 const { asyncWrap } = require("../utils/errorHandler");
 const { validateToken } = require("../utils/validateToken");
 const productRouter = express.Router();
 
 productRouter.get("/", validateToken, asyncWrap(productController.findProducts));
 productRouter.get("/:id", validateToken, asyncWrap(productController.findProductByIdWithOther));
+productRouter.get("/:id/reviews", validateToken, asyncWrap(reviewController.findReviewByProductId));
+// TODO 위클리 베스트 API 구현하기
 
 module.exports = { productRouter };

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,7 +1,9 @@
 const userService = require("./userService");
 const productService = require("./productService");
+const reviewService = require("./reviewService");
 
 module.exports = {
   userService,
   productService,
+  reviewService,
 };

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,9 +1,11 @@
 const userService = require("./userService");
 const productService = require("./productService");
 const reviewService = require("./reviewService");
+const likeService = require("./likeService");
 
 module.exports = {
   userService,
   productService,
   reviewService,
+  likeService,
 };

--- a/src/services/likeService.js
+++ b/src/services/likeService.js
@@ -1,0 +1,16 @@
+const { likeDao, productDao } = require("../models");
+const { throwError } = require("../utils/throwError");
+
+const pushLike = async (userId, productId) => {
+  const product = await productDao.findProductById(productId);
+  if (!product) throwError(404, "PRODUCT_NOT_FOUND");
+
+  const like = await likeDao.findByIds(userId, productId);
+  if (like) {
+    await likeDao.deleteByIds(userId, productId);
+  } else {
+    await likeDao.save(userId, productId);
+  }
+};
+
+module.exports = { pushLike };

--- a/src/services/productService.js
+++ b/src/services/productService.js
@@ -2,15 +2,19 @@ const { productDao, productQueryBuilder } = require("../models");
 const { throwError } = require("../utils/throwError");
 
 const findProducts = async (userId, category, sort, page) => {
+  if (page < 1) throwError(400, "PAGE_STARTS_FROM_ONE");
+  if (sort < 0) throwError(400, "SORT_STARTS_FROM_ZERO");
+  if (limit < 0) throwError(400, "LIMIT_STARTS_FROM_ZERO");
+
   const categoryQuery = productQueryBuilder.categoryQuery(category);
   const sortQuery = productQueryBuilder.sortQuery(sort);
 
   const products = await productDao.findProducts(userId, categoryQuery, sortQuery, page);
-  const countProducts = await productDao.countProducts(categoryQuery);
+  const total = await productDao.countProducts(categoryQuery);
 
   return {
     products,
-    dataCount: countProducts,
+    total,
   };
 };
 

--- a/src/services/productService.js
+++ b/src/services/productService.js
@@ -22,7 +22,7 @@ const findProducts = async (userId, category, sort, page) => {
 const findProductByIdWithOther = async (userId, productId) => {
   const product = await productDao.findProductById(productId);
 
-  if (!product) throwError(404, "CONTENT_NOT_FOUND");
+  if (!product) throwError(404, "PRODUCT_NOT_FOUND");
 
   return await productDao.findProductByIdWithOther(userId, productId);
 };

--- a/src/services/reviewService.js
+++ b/src/services/reviewService.js
@@ -1,0 +1,25 @@
+const { reviewDao, productDao, reviewQueryBuilder } = require("../models");
+const { throwError } = require("../utils/throwError");
+
+const findReviewByProductId = async (userId, productId, image, page) => {
+  if (page < 1) throwError(400, "PAGE_STARTS_FROM_ONE");
+  if (image < 0) throwError(400, "IMAGE_STARTS_FROM_ZERO");
+
+  const product = await productDao.findProductById(productId);
+  if (!product) throwError(404, "PRODUCT_NOT_FOUND");
+
+  const whereQuery = reviewQueryBuilder.whereQuery(image);
+  const whereQueryForCount = reviewQueryBuilder.whereQuery(image, true);
+
+  const reviews = await reviewDao.findReviewByProductId(userId, productId, whereQuery, page);
+  const total = await reviewDao.countReviews(whereQueryForCount);
+
+  return {
+    reviews,
+    total,
+  };
+};
+
+module.exports = {
+  findReviewByProductId,
+};

--- a/src/utils/validateToken.js
+++ b/src/utils/validateToken.js
@@ -2,12 +2,13 @@ const jwt = require("jsonwebtoken");
 const { userService } = require("../services");
 const { throwError } = require("../utils/throwError");
 
-const permitCheck = (method, endPoint) => {
-  const permitUrls = {
-    "/products": "GET",
-    "/products/:id": "GET",
-  };
+const permitUrls = {
+  "/products": "GET",
+  "/products/:id": "GET",
+  "/products/:id/reviews": "GET",
+};
 
+const permitCheck = (method, endPoint) => {
   endPoint = endPoint.split("?")[0];
   const pathIdx = endPoint.lastIndexOf("/") + 1;
   if (pathIdx === endPoint.length) endPoint = endPoint.slice(0, pathIdx - 1);


### PR DESCRIPTION
## 1. 본 PR이 우리 팀의 웹 서비스 제품성에 어떠한 기여를 하였고, <br> 사용자에게 어떠한 기대효과를 전달하는지 작성해주세요.

- 내 PR이 제품 내 어떠한 기능적인 배경/전후맥락 가운데 개발되었나요?

  제품 상세 페이지에서 하단에 리뷰 목록이 보입니다. 제품의 내용을 이미지로 길게 하기 때문에, 제품 상세 API에 리뷰를 같이 보내지 않고 리뷰 목록 조회 API를 따로 만들기로 했습니다.

 좋아요 기능은 누르면 좋아요가 등록되는 기능으로, 등록되어 있으면 삭제하도록 만들었습니다.

- 내 PR이 Merge 됨으로써 유저에게 전달되는 편익/기대효과는 무엇일까요?

  제품 상세 페이지에서 제품의 내용이 이미지로 전달되고, 리뷰는 페이지 하단에 있어서 API를 따로 분리했습니다.

 제품 목록, 제품 상세에서 좋아요 버튼이 있어 구현했습니다.

<br />

## 2. 이 브랜치에서 어떤 내용을 개발했는지 큰 제목과 상세 내역을 적어주세요.

제품 리뷰 목록 조회 기능 추가

- 퀴리 파라미터로 받는 page, image를 에러 핸들링
- 패스 파라미터로 받는 productId로 존재하는 제품인지 확인하여 에러 핸들링

좋아요 기능 추가

- 바디로 받는 productId로 존재하는 제품인지 확인하여 에러 핸들링

<br />

## 3. 개발한 화면을 캡쳐해서 첨부 해 주세요. 
<br />

<img width="658" alt="image" src="https://github.com/wecode-bootcamp-korea/49-2nd-TeaTime-backend/assets/113500815/1f0d12d1-c7d2-4ba1-8ea5-2de914a0b3c2">
<img width="837" alt="image" src="https://github.com/wecode-bootcamp-korea/49-2nd-TeaTime-backend/assets/113500815/7156b513-3112-4d8c-b11e-12dded0278df">


<br />

## 4. 이 브랜치에서 개발하면서 느꼇던 개발 성장포인트를 적어주세요.

- 구조분해할당 기능으로 받아오는 값들은 기본값을 줄 수 있어, page의 기본값을 1로 하여 쿼리 파라미터로 page가 안 들어와도 1 페이지가 뜨게 만들었습니다.

  <br />
